### PR TITLE
feat: note adding (FINISHED) and getting (FINISHED)

### DIFF
--- a/src/app/api/notes/list/route.ts
+++ b/src/app/api/notes/list/route.ts
@@ -1,0 +1,23 @@
+import prisma from "@/utils/prisma";
+import { NextRequest, NextResponse } from "next/server";
+
+export async function GET(request: NextRequest) {
+    const params = request.nextUrl.searchParams;
+    const noteID = Number(params.get("noteid"));
+    const userID = 1; // TODO need to be retrieved from the token
+    let note;
+    if (noteID && !Number.isNaN(noteID)) {
+        note = await prisma.notes.findMany({
+            where: { ownerId: userID },
+            cursor: { id: noteID },
+            take: 10,
+            skip: 1,
+        });
+    } else {
+        note = await prisma.notes.findMany({
+            where: { ownerId: userID },
+            take: 10,
+        });
+    }
+    return NextResponse.json(note);
+}

--- a/src/app/api/notes/new/route.ts
+++ b/src/app/api/notes/new/route.ts
@@ -1,0 +1,37 @@
+import prisma from "@/utils/prisma";
+import { NextRequest, NextResponse } from "next/server";
+
+export async function POST(request: NextRequest) {
+    const userID = 1; // TODO need to be retrieved from the token
+    if (request.body) {
+        try {
+            const body = JSON.parse(await request.text());
+            const { content, noteIV, contentChecksum, creationTimestamp } =
+                body;
+            const { id } = await prisma.notes.create({
+                data: {
+                    ownerId: userID,
+                    content,
+                    noteIV,
+                    atachedFiles: [],
+                    contentChecksum,
+                    creationTimestamp,
+                    editTimestamp: null,
+                },
+            });
+            return NextResponse.json({ success: true, data: { id } });
+        } catch (e) {
+            console.error(e);
+            return NextResponse.json({ success: false }, { status: 500 });
+        }
+    } else {
+        return NextResponse.json(
+            {
+                success: false,
+            },
+            {
+                status: 400,
+            }
+        );
+    }
+}

--- a/src/app/api/notes/new/route.ts
+++ b/src/app/api/notes/new/route.ts
@@ -1,29 +1,39 @@
+import noteAdding from "@/types/noteAdding";
 import prisma from "@/utils/prisma";
 import { NextRequest, NextResponse } from "next/server";
 
 export async function POST(request: NextRequest) {
     const userID = 1; // TODO need to be retrieved from the token
-    if (request.body) {
+    const data = await request.text();
+    if (data) {
         try {
-            const body = JSON.parse(await request.text());
+            const body: noteAdding = JSON.parse(data);
             const { content, noteIV, contentChecksum, creationTimestamp } =
                 body;
-            const { id } = await prisma.notes.create({
-                data: {
-                    ownerId: userID,
-                    content,
-                    noteIV,
-                    atachedFiles: [],
-                    contentChecksum,
-                    creationTimestamp,
-                    editTimestamp: null,
-                },
-            });
-            return NextResponse.json({ success: true, data: { id } });
+            if (
+                [content, noteIV, contentChecksum, creationTimestamp].every(
+                    (value) => typeof value == "string"
+                )
+            ) {
+                const { id } = await prisma.notes.create({
+                    data: {
+                        ownerId: userID,
+                        content,
+                        noteIV,
+                        atachedFiles: [],
+                        contentChecksum,
+                        creationTimestamp,
+                        editTimestamp: null,
+                    },
+                });
+                return NextResponse.json({ success: true, data: { id } });
+            } else {
+                return NextResponse.json({ success: false }, { status: 400 });
+            }
         } catch (e) {
             console.error(e);
-            return NextResponse.json({ success: false }, { status: 500 });
         }
+        return NextResponse.json({ success: false }, { status: 500 });
     } else {
         return NextResponse.json(
             {

--- a/src/types/noteAdding.ts
+++ b/src/types/noteAdding.ts
@@ -1,0 +1,8 @@
+type noteAdding = {
+    content: string;
+    noteIV: string;
+    contentChecksum: string;
+    creationTimestamp: string;
+};
+
+export default noteAdding;


### PR DESCRIPTION
# adding

- Added router for note adding endpoint (`/api/notes/new`) this endpoint need the note data in the body of the request to create a request

# getting

- Added router for the note listing endpoint (`/api/notes/list`) this endpoint use a optional parameter `noteid` (case insensitive) to fetch notes after a particular note.
